### PR TITLE
chore: change order of industry select options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
   - Removed internal tools and utilities
   - Rebased the entire history to remove secrets and unrelated code
   - Cleaned up dead links
+- Changed order of industry select options [#22](https://github.com/sovity/authority-portal/issues/22)
 
 ### Known issues
 

--- a/authority-portal-frontend/src/app/common/components/form-elements/industry-select/industry-select.component.ts
+++ b/authority-portal-frontend/src/app/common/components/form-elements/industry-select/industry-select.component.ts
@@ -10,7 +10,6 @@
  * Contributors:
  *      sovity GmbH - initial implementation
  */
-
 import {Component, HostBinding, Input} from '@angular/core';
 import {FormControl} from '@angular/forms';
 
@@ -49,7 +48,6 @@ export class IndustrySelectComponent {
     'Meteorological services',
     'Micromobility provider',
     'Municipality',
-    'Other',
     'Passenger transportation',
     'Research & Development',
     'Sensor supplier',
@@ -57,5 +55,6 @@ export class IndustrySelectComponent {
     'Telecommunication',
     'Tourism',
     'Traffic engineering',
+    'Other',
   ];
 }


### PR DESCRIPTION
_What issues does this PR close?_
closes #22 Register organization: Misplacement of "Other" Option in Industry Field Dropdown List

New order:
![image](https://github.com/sovity/authority-portal/assets/66363651/2cd64790-e554-47cd-9893-6eaa7455e639)

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
