### PR TITLE
Fix user can skip step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch
 
+- Fixed user being able to skip the steps in multiple components ([#121](https://github.com/sovity/authority-portal/issues/121))
 - Fixed Keycloak notifications, OTP pages ([#146](https://github.com/sovity/authority-portal/issues/146)), ([#151](https://github.com/sovity/authority-portal/issues/151))
 - Fixed provided connectors' statuses missing on the dashboard ([#138](https://github.com/sovity/authority-portal/issues/138))
 - Fixed "Hosted By Name" column in Connector CSV report ([#149](https://github.com/sovity/authority-portal/issues/149))
@@ -298,6 +299,7 @@ Major release, containing a UI rework and several new features.
   - Replace [MDS theme](authority-portal-keycloak/mds-theme) with the new version
   - Keycloak IAM needs to be upgraded to version 23.0.4
 - Portal Backend
+
   - Added environment variables
 
     ```yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,10 +298,9 @@ Major release, containing a UI rework and several new features.
 - Keycloak
   - Replace [MDS theme](authority-portal-keycloak/mds-theme) with the new version
   - Keycloak IAM needs to be upgraded to version 23.0.4
+
 - Portal Backend
-
   - Added environment variables
-
     ```yaml
     # CaaS Portal API Client Auth
     # will be provided by sovity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch
 
-- Fixed user being able to skip the steps in multiple components ([#121](https://github.com/sovity/authority-portal/issues/121))
+- Fixed user being able to skip to the final step without submitting in multiple components ([#121](https://github.com/sovity/authority-portal/issues/121))
 - Fixed Keycloak notifications, OTP pages ([#146](https://github.com/sovity/authority-portal/issues/146)), ([#151](https://github.com/sovity/authority-portal/issues/151))
 - Fixed provided connectors' statuses missing on the dashboard ([#138](https://github.com/sovity/authority-portal/issues/138))
 - Fixed "Hosted By Name" column in Connector CSV report ([#149](https://github.com/sovity/authority-portal/issues/149))

--- a/authority-portal-frontend/src/app/core/api/fake-backend/fake-backend.ts
+++ b/authority-portal-frontend/src/app/core/api/fake-backend/fake-backend.ts
@@ -328,13 +328,6 @@ export const AUTHORITY_PORTAL_FAKE_BACKEND: FetchAPI = async (
     .on('POST', () => {
       const request = RegistrationRequestDtoFromJSON(body);
       const result = registerOrganization(request);
-      return failed(409);
-    })
-
-    .url('registration')
-    .on('POST', () => {
-      const request = RegistrationRequestDtoFromJSON(body);
-      const result = registerOrganization(request);
       return ok(IdResponseToJSON(result));
     })
 

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page-form-model.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page-form-model.ts
@@ -44,13 +44,11 @@ export const DEFAULT_CERTIFICATE_TAB_FORM_VALUE: CertificateTabFormValue =
 export interface ProvideConnectorPageFormModel {
   connectorTab: FormGroup<ConnectorTabFormModel>;
   certificateTab: FormGroup<CertificateTabFormModel>;
-  canSwitchTabs: FormControl<boolean>;
 }
 export const DEFAULT_PROVIDE_CONNECTOR_PAGE_FORM_VALUE: ProvideConnectorPageFormValue =
   {
     connectorTab: DEFAULT_CONNECTOR_TAB_FORM_VALUE,
     certificateTab: DEFAULT_CERTIFICATE_TAB_FORM_VALUE,
-    canSwitchTabs: true,
   };
 export type ProvideConnectorPageFormValue =
   ɵFormGroupRawValue<ProvideConnectorPageFormModel>;

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page-form.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page-form.ts
@@ -83,7 +83,6 @@ export class ProvideConnectorPageForm {
     );
 
     return this.formBuilder.nonNullable.group({
-      canSwitchTabs: [true, Validators.requiredTrue],
       connectorTab,
       certificateTab,
     });

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page.component.html
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page.component.html
@@ -8,8 +8,7 @@
     <mat-step
       color="accent"
       [editable]="state.state === 'editing' || state.state === 'error'"
-      [completed]="state.state === 'success'"
-      [stepControl]="form.connectorTab">
+      [completed]="state.state === 'success' || form.connectorTab.valid">
       <form class="flex flex-col w-full justify-center">
         <ng-template matStepLabel>Add Connector Details</ng-template>
         <div
@@ -96,8 +95,7 @@
     <mat-step
       color="accent"
       [editable]="state.state === 'editing' || state.state === 'error'"
-      [completed]="state.state === 'success'"
-      [stepControl]="form.certificateTab">
+      [completed]="state.state === 'success'">
       <ng-template matStepLabel>Generate Certificate</ng-template>
 
       <div class="flex justify-center items-center">
@@ -121,7 +119,9 @@
         <button
           class="btn-accent"
           [disabledBtn]="
-            state.state === 'submitting' || !form.certificateTab.valid
+            state.state === 'submitting' ||
+            !form.connectorTab.valid ||
+            !form.certificateTab.valid
           "
           (click)="registerConnector()">
           {{ createActionName }}
@@ -131,10 +131,7 @@
     <!-- Generate Certificate Step-->
 
     <!-- Final Step -->
-    <mat-step
-      color="accent"
-      [editable]="false"
-      [stepControl]="form.group.controls.canSwitchTabs">
+    <mat-step color="accent" [editable]="false">
       <ng-template matStepLabel>Setup Connector</ng-template>
 
       <app-connector-registering-success-message-page

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page.component.ts
@@ -103,7 +103,11 @@ export class ProvideConnectorPageComponent implements OnInit, OnDestroy {
         mdsId,
         () => this.form.group.enable(),
         () => this.form.group.disable(),
-        () => this.stepper.next(),
+        () => {
+          setTimeout(() => {
+            this.stepper.next();
+          }, 1000);
+        },
       ),
     );
   }

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/provide-connector-page/provide-connector-page/provide-connector-page.component.ts
@@ -106,7 +106,7 @@ export class ProvideConnectorPageComponent implements OnInit, OnDestroy {
         () => {
           setTimeout(() => {
             this.stepper.next();
-          }, 1000);
+          }, 0);
         },
       ),
     );

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page-form-model.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page-form-model.ts
@@ -41,14 +41,12 @@ export const DEFAULT_CERTIFICATE_TAB_FORM_VALUE: CertificateTabFormValue =
 export interface RegisterCentralComponentPageFormModel {
   componentTab: FormGroup<ComponentTabFormModel>;
   certificateTab: FormGroup<CertificateTabFormModel>;
-  canSwitchTabs: FormControl<boolean>;
 }
 
 export const DEFAULT_REGISTER_CENTRAL_COMPONENT_PAGE_FORM_VALUE: RegisterCentralComponentPageFormValue =
   {
     componentTab: DEFAULT_COMPONENT_TAB_FORM_VALUE,
     certificateTab: DEFAULT_CERTIFICATE_TAB_FORM_VALUE,
-    canSwitchTabs: true,
   };
 export type RegisterCentralComponentPageFormValue =
   ɵFormGroupRawValue<RegisterCentralComponentPageFormModel>;

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page-form.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page-form.ts
@@ -75,7 +75,6 @@ export class RegisterCentralComponentPageForm {
     );
 
     return this.formBuilder.nonNullable.group({
-      canSwitchTabs: [true, Validators.requiredTrue],
       componentTab,
       certificateTab,
     });

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.html
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.html
@@ -4,10 +4,9 @@
     <mat-step
       color="accent"
       [editable]="state.state === 'editing' || state.state === 'error'"
-      [completed]="state.state === 'success'"
-      [stepControl]="form.componentTab">
+      [completed]="state.state === 'success' || form.componentTab.valid">
       <form class="flex flex-col w-full justify-center">
-        <ng-template matStepLabel>Add Connector Details</ng-template>
+        <ng-template matStepLabel>Add Component Details</ng-template>
         <div
           class="select-none flex flex-col justify-center items-center my-10 w-2/3 mx-auto">
           <!-- Central Component Name -->
@@ -65,14 +64,13 @@
         </div>
       </form>
     </mat-step>
-    <!-- connector details Step -->
+    <!-- Central Component details Step -->
 
     <!-- Generate Certificate Step-->
     <mat-step
       color="accent"
       [editable]="state.state === 'editing' || state.state === 'error'"
-      [completed]="state.state === 'success'"
-      [stepControl]="form.componentTab">
+      [completed]="state.state === 'success'">
       <ng-template matStepLabel>Generate Certificate</ng-template>
 
       <div class="flex justify-center items-center">
@@ -94,7 +92,9 @@
         <button
           class="btn-accent"
           [disabledBtn]="
-            state.state === 'submitting' || !form.certificateTab.valid
+            state.state === 'submitting' ||
+            !form.componentTab.valid ||
+            !form.certificateTab.valid
           "
           (click)="registerComponent()">
           {{ createActionName }}
@@ -104,10 +104,7 @@
     <!-- Generate Certificate Step-->
 
     <!-- Final Step -->
-    <mat-step
-      color="accent"
-      [editable]="false"
-      [stepControl]="form.group.controls.canSwitchTabs">
+    <mat-step color="accent" [editable]="false">
       <ng-template matStepLabel>Setup Central Component</ng-template>
       <div class="my-12 flex flex-col justify-center items-center text-center">
         <h2 class="wizard-end-title">Finish setting up your component!</h2>

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.ts
@@ -113,7 +113,7 @@ export class RegisterCentralComponentPageComponent
         () => {
           setTimeout(() => {
             this.stepper.next();
-          }, 1000);
+          }, 0);
         },
       ),
     );

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.ts
@@ -110,7 +110,11 @@ export class RegisterCentralComponentPageComponent
         request,
         () => this.form.group.enable(),
         () => this.form.group.disable(),
-        () => this.stepper.next(),
+        () => {
+          setTimeout(() => {
+            this.stepper.next();
+          }, 1000);
+        },
       ),
     );
   }

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page-form-model.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page-form-model.ts
@@ -43,14 +43,12 @@ export const DEFAULT_CERTIFICATE_TAB_FORM_VALUE: CertificateTabFormValue =
 export interface RegisterConnectorPageFormModel {
   connectorTab: FormGroup<ConnectorTabFormModel>;
   certificateTab: FormGroup<CertificateTabFormModel>;
-  canSwitchTabs: FormControl<boolean>;
 }
 
 export const DEFAULT_REGISTER_CONNECTOR_PAGE_FORM_VALUE: RegisterConnectorPageFormValue =
   {
     connectorTab: DEFAULT_CONNECTOR_TAB_FORM_VALUE,
     certificateTab: DEFAULT_CERTIFICATE_TAB_FORM_VALUE,
-    canSwitchTabs: true,
   };
 export type RegisterConnectorPageFormValue =
   ɵFormGroupRawValue<RegisterConnectorPageFormModel>;

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page-form.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page-form.ts
@@ -79,7 +79,6 @@ export class RegisterConnectorPageForm {
     );
 
     return this.formBuilder.nonNullable.group({
-      canSwitchTabs: [true, Validators.requiredTrue],
       connectorTab,
       certificateTab,
     });

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page.component.html
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page.component.html
@@ -8,8 +8,7 @@
     <mat-step
       color="accent"
       [editable]="state.state === 'editing' || state.state === 'error'"
-      [completed]="state.state === 'success'"
-      [stepControl]="form.connectorTab">
+      [completed]="state.state === 'success' || form.connectorTab.valid">
       <form class="flex flex-col w-full justify-center">
         <ng-template matStepLabel>Add Connector Details</ng-template>
         <div
@@ -89,8 +88,7 @@
     <mat-step
       color="accent"
       [editable]="state.state === 'editing' || state.state === 'error'"
-      [completed]="state.state === 'success'"
-      [stepControl]="form.certificateTab">
+      [completed]="state.state === 'success'">
       <ng-template matStepLabel>Generate Certificate</ng-template>
 
       <div class="flex justify-center items-center">
@@ -112,7 +110,9 @@
         <button
           class="btn-accent"
           [disabledBtn]="
-            state.state === 'submitting' || !form.certificateTab.valid
+            state.state === 'submitting' ||
+            !form.connectorTab.valid ||
+            !form.certificateTab.valid
           "
           (click)="registerConnector()">
           {{ createActionName }}
@@ -122,10 +122,7 @@
     <!-- Generate Certificate Step-->
 
     <!-- Final Step -->
-    <mat-step
-      color="accent"
-      [editable]="false"
-      [stepControl]="form.group.controls.canSwitchTabs">
+    <mat-step color="accent" [editable]="false">
       <ng-template matStepLabel>Setup Connector</ng-template>
 
       <app-connector-registering-success-message-page

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page.component.ts
@@ -97,7 +97,11 @@ export class RegisterConnectorPageComponent implements OnInit, OnDestroy {
         },
         () => this.form.group.enable(),
         () => this.form.group.disable(),
-        () => this.stepper.next(),
+        () => {
+          setTimeout(() => {
+            this.stepper.next();
+          }, 1000);
+        },
       ),
     );
   }

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-connector-page/register-connector-page/register-connector-page.component.ts
@@ -100,7 +100,7 @@ export class RegisterConnectorPageComponent implements OnInit, OnDestroy {
         () => {
           setTimeout(() => {
             this.stepper.next();
-          }, 1000);
+          }, 0);
         },
       ),
     );

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-create-page/organization-create-page/organization-create-page.component.html
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-create-page/organization-create-page/organization-create-page.component.html
@@ -20,8 +20,7 @@
         <mat-step
           color="accent"
           [editable]="state.state === 'editing' || state.state === 'error'"
-          [completed]="state.state === 'success'"
-          [stepControl]="userForm">
+          [completed]="userForm.valid || state.state === 'success'">
           <div class="flex flex-col px-1 md:px-8 w-full">
             <ng-template matStepLabel>User Details</ng-template>
             <app-user-create-form
@@ -49,8 +48,7 @@
           color="accent"
           editable="false"
           [editable]="state.state === 'editing' || state.state === 'error'"
-          [completed]="state.state === 'success'"
-          [stepControl]="orgForm">
+          [completed]="state.state === 'success'">
           <div class="flex flex-col px-1 md:px-8 w-full">
             <ng-template matStepLabel>Organization Profile</ng-template>
             <h3 class="wizard-step-title">Organization Profile</h3>
@@ -69,7 +67,7 @@
 
               <button
                 class="btn-accent"
-                [disabledBtn]="!parentFormGroup.valid || loading"
+                [disabledBtn]="!userForm.valid || !orgForm.valid || loading"
                 (click)="submit()">
                 Register
               </button>
@@ -79,7 +77,7 @@
         <!-- Organization profile form -->
 
         <!-- final step -->
-        <mat-step [editable]="false" [stepControl]="parentFormGroup">
+        <mat-step [editable]="false">
           <ng-template matStepLabel>Email Verification</ng-template>
           <div
             class="my-12 flex flex-col justify-center items-center text-center">

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-create-page/organization-create-page/organization-create-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-create-page/organization-create-page/organization-create-page.component.ts
@@ -107,7 +107,6 @@ export class OrganizationCreatePageComponent implements OnInit, OnDestroy {
     );
 
     return this.formBuilder.nonNullable.group({
-      isEditable: [true, Validators.requiredTrue],
       userTab,
       organizationTab,
     });
@@ -135,8 +134,9 @@ export class OrganizationCreatePageComponent implements OnInit, OnDestroy {
         () => this.parentFormGroup.enable(),
         () => this.parentFormGroup.disable(),
         () => {
-          this.stepper.next();
-          this.parentFormGroup.controls.isEditable.setValue(false);
+          setTimeout(() => {
+            this.stepper.next();
+          }, 0);
         },
       ),
     );

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-create-page/organization-create-page/organization-create-page.form-model.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-create-page/organization-create-page/organization-create-page.form-model.ts
@@ -34,7 +34,6 @@ export type RegistrationOrganizationTabFormValue =
   ɵFormGroupRawValue<RegistrationOrganizationTabFormModel>;
 
 export interface RegistrationWizardFormModel {
-  isEditable: FormControl<boolean>;
   userTab: FormGroup<RegistrationUserTabFormModel>;
   organizationTab: FormGroup<RegistrationOrganizationTabFormModel>;
 }
@@ -44,7 +43,6 @@ export type RegistrationWizardFormValue =
 
 export const DEFAULT_REGISTRATION_WIZARD_FORM_VALUE: RegistrationWizardFormValue =
   {
-    isEditable: true,
     userTab: DEFAULT_USER_CREATE_FORM_MODEL,
     organizationTab: {
       ...DEFAULT_ORGANIZATION_CREATE_FORM_MODEL,

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
@@ -25,7 +25,8 @@
       <mat-step
         color="accent"
         [editable]="state.state === 'editing' || state.state === 'error'"
-        [completed]="userForm.valid">
+        [completed]="state.state === 'success'"
+        [stepControl]="userForm">
         <div class="flex flex-col px-1 md:px-8 w-full">
           <ng-template matStepLabel>User Profile</ng-template>
 

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
@@ -25,8 +25,7 @@
       <mat-step
         color="accent"
         [editable]="state.state === 'editing' || state.state === 'error'"
-        [completed]="state.state === 'success'"
-        [stepControl]="userForm">
+        [completed]="userForm.valid">
         <div class="flex flex-col px-1 md:px-8 w-full">
           <ng-template matStepLabel>User Profile</ng-template>
 

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
@@ -25,8 +25,9 @@
       <mat-step
         color="accent"
         [editable]="state.state === 'editing' || state.state === 'error'"
-        [completed]="state.state === 'success'"
-        [stepControl]="userForm">
+        [completed]="
+          userForm.valid || parentFormGroup.controls.submitted.value
+        ">
         <div class="flex flex-col px-1 md:px-8 w-full">
           <ng-template matStepLabel>User Profile</ng-template>
 
@@ -67,8 +68,7 @@
         *ngIf="state.onboardingType === 'USER_ORGANIZATION_ONBOARDING'"
         color="accent"
         [editable]="state.state === 'editing' || state.state === 'error'"
-        [completed]="state.state === 'success'"
-        [stepControl]="orgProfileForm">
+        [completed]="parentFormGroup.controls.submitted.value">
         <div class="flex flex-col px-1 md:px-8 w-full">
           <ng-template matStepLabel>Organization Profile</ng-template>
 
@@ -88,7 +88,9 @@
             <button
               class="btn-accent"
               [disabledBtn]="
-                !parentFormGroup.valid || state.state === 'submitting'
+                !userForm.valid ||
+                !orgForm.valid ||
+                state.state === 'submitting'
               "
               (click)="submit()">
               Submit

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.html
@@ -25,9 +25,7 @@
       <mat-step
         color="accent"
         [editable]="state.state === 'editing' || state.state === 'error'"
-        [completed]="
-          userForm.valid || parentFormGroup.controls.submitted.value
-        ">
+        [completed]="userForm.valid || state.state === 'success'">
         <div class="flex flex-col px-1 md:px-8 w-full">
           <ng-template matStepLabel>User Profile</ng-template>
 
@@ -68,7 +66,7 @@
         *ngIf="state.onboardingType === 'USER_ORGANIZATION_ONBOARDING'"
         color="accent"
         [editable]="state.state === 'editing' || state.state === 'error'"
-        [completed]="parentFormGroup.controls.submitted.value">
+        [completed]="state.state === 'success'">
         <div class="flex flex-col px-1 md:px-8 w-full">
           <ng-template matStepLabel>Organization Profile</ng-template>
 

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.ts
@@ -11,7 +11,7 @@
  *      sovity GmbH - initial implementation
  */
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {MatStepper} from '@angular/material/stepper';
 import {Subject, take, takeUntil} from 'rxjs';
 import {filter, map} from 'rxjs/operators';

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.ts
@@ -148,8 +148,6 @@ export class OrganizationOnboardPageComponent implements OnInit {
     );
 
     return this.formBuilder.nonNullable.group({
-      isEditable: [true, Validators.requiredTrue],
-      submitted: [false, Validators.requiredTrue],
       userTab,
       organizationTab,
     });
@@ -165,8 +163,6 @@ export class OrganizationOnboardPageComponent implements OnInit {
         () => this.parentFormGroup.enable(),
         () => this.parentFormGroup.disable(),
         () => {
-          this.parentFormGroup.controls.submitted.setValue(true);
-          this.parentFormGroup.controls.isEditable.setValue(false);
           setTimeout(() => {
             this.stepper.next();
           }, 0);

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.component.ts
@@ -11,7 +11,7 @@
  *      sovity GmbH - initial implementation
  */
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {MatStepper} from '@angular/material/stepper';
 import {Subject, take, takeUntil} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
@@ -149,6 +149,7 @@ export class OrganizationOnboardPageComponent implements OnInit {
 
     return this.formBuilder.nonNullable.group({
       isEditable: [true, Validators.requiredTrue],
+      submitted: [false, Validators.requiredTrue],
       userTab,
       organizationTab,
     });
@@ -164,8 +165,11 @@ export class OrganizationOnboardPageComponent implements OnInit {
         () => this.parentFormGroup.enable(),
         () => this.parentFormGroup.disable(),
         () => {
-          this.stepper.next();
+          this.parentFormGroup.controls.submitted.setValue(true);
           this.parentFormGroup.controls.isEditable.setValue(false);
+          setTimeout(() => {
+            this.stepper.next();
+          }, 0);
         },
       ),
     );

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-mapper.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-mapper.ts
@@ -46,6 +46,7 @@ export function buildInitialOnboardingFormValue(
     userTab,
     organizationTab,
     isEditable: true,
+    submitted: false,
   };
 }
 

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-mapper.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-mapper.ts
@@ -45,8 +45,6 @@ export function buildInitialOnboardingFormValue(
   return {
     userTab,
     organizationTab,
-    isEditable: true,
-    submitted: false,
   };
 }
 

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-model.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-model.ts
@@ -31,6 +31,7 @@ export type OnboardingOrganizationTabFormValue =
 
 export interface OnboardingWizardFormModel {
   isEditable: FormControl<boolean>;
+  submitted: FormControl<boolean>;
   userTab: FormGroup<OnboardingUserTabFormModel>;
   organizationTab: FormGroup<OnboardingOrganizationTabFormModel>;
 }

--- a/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-model.ts
+++ b/authority-portal-frontend/src/app/pages/registration-pages/organization-onboard-page/organization-onboard-page/organization-onboard-page.form-model.ts
@@ -30,8 +30,6 @@ export type OnboardingOrganizationTabFormValue =
   ɵFormGroupRawValue<OnboardingOrganizationTabFormModel>;
 
 export interface OnboardingWizardFormModel {
-  isEditable: FormControl<boolean>;
-  submitted: FormControl<boolean>;
   userTab: FormGroup<OnboardingUserTabFormModel>;
   organizationTab: FormGroup<OnboardingOrganizationTabFormModel>;
 }


### PR DESCRIPTION
_What issues does this PR close?_
closes #121 Organisation registration - User can skip to step 3 and email sent message is displayed

"After filling in all details on the User Profile page and Org profile page, directly click on Email Verification from pagination, before clicking on the Register button.

It gives an acknowledgment message to verify email has been sent but no email appears and if navigate back it shows a yes tick mark. The email is sent only when the user clicks on the Register button.

Same behavior was observed in other components with mat-stepper:

+ create-organization
+ organization-onboarding
+ provide-connector
+ register-connector
+ register-central-component
"

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
