### PR TITLE
Keycloak update to 24.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 ### Deployment Migration Notes
 
+- Keycloak
+  - Keycloak IAM must be updated to version `24.0.4`. Follow the [Keycloak upgrade guide](https://www.keycloak.org/docs/24.0.0/upgrading/) for more information.
+
 #### Compatible Versions
 
 - Authority Portal Backend Docker Image: `ghcr.io/sovity/authority-portal-backend:{{ version }}`

--- a/authority-portal-backend/authority-portal-quarkus/build.gradle.kts
+++ b/authority-portal-backend/authority-portal-quarkus/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation("io.quarkus:quarkus-scheduler")
     implementation("io.quarkus:quarkus-oidc")
     implementation("io.quarkus:quarkus-keycloak-authorization")
-    implementation("io.quarkus:quarkus-keycloak-admin-client-reactive:3.6.6")
+    implementation("io.quarkus:quarkus-keycloak-admin-client-reactive:3.11.0")
     implementation("io.quarkus:quarkus-elytron-security-properties-file")
     implementation("io.quarkus:quarkus-arc")
     implementation("io.quarkus:quarkus-flyway")


### PR DESCRIPTION
This PR updates the Keycloak admin client library to enable updating Keycloak to 24.0.4

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [x] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
