### PR TITLE
feat: catalog pages now sync deployment environment to url for better linkability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch
 
+- Fix deployment environment not syncing in URLs for the catalog
+
 ### Known issues
 
 ### Deployment Migration Notes

--- a/authority-portal-frontend/src/app/core/global-state/deployment-environment-url-sync.service.ts
+++ b/authority-portal-frontend/src/app/core/global-state/deployment-environment-url-sync.service.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024 sovity GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *      sovity GmbH - initial implementation
+ */
+import {Injectable} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+import {Observable, combineLatest, takeUntil} from 'rxjs';
+import {take} from 'rxjs/operators';
+import {Store} from '@ngxs/store';
+import {DeploymentEnvironmentDto} from '../../../../../authority-portal-backend/authority-portal-api-client-ts';
+import {SwitchEnvironment} from './global-state-actions';
+import {GlobalStateUtils} from './global-state-utils';
+
+@Injectable({providedIn: 'root'})
+export class DeploymentEnvironmentUrlSyncService {
+  private readonly environmentIdQueryParam = 'environmentId';
+
+  constructor(
+    private store: Store,
+    private router: Router,
+    private globalStateUtils: GlobalStateUtils,
+  ) {}
+
+  updateFromUrlOnce(route: ActivatedRoute, until$: Observable<unknown>) {
+    const environmentId: string | undefined =
+      route.snapshot.queryParams[this.environmentIdQueryParam];
+    if (!environmentId) {
+      return;
+    }
+
+    this.withAvailableEnvironments((available, current) => {
+      if (current.environmentId === environmentId) {
+        return;
+      }
+
+      const desiredEnvironment = available.find(
+        (it) => it.environmentId === environmentId,
+      );
+
+      if (desiredEnvironment) {
+        this.store.dispatch(new SwitchEnvironment(desiredEnvironment));
+      }
+    }, until$);
+  }
+
+  syncToUrl(activatedRoute: ActivatedRoute, until$: Observable<unknown>) {
+    let queryParamEnvironmentId: string | undefined;
+
+    activatedRoute.queryParams
+      .pipe(takeUntil(until$))
+      .subscribe(
+        (params) =>
+          (queryParamEnvironmentId = params[this.environmentIdQueryParam]),
+      );
+
+    this.globalStateUtils.deploymentEnvironment$
+      .pipe(takeUntil(until$))
+      .subscribe((environment) => {
+        if (environment.environmentId === queryParamEnvironmentId) {
+          return;
+        }
+
+        this.router.navigate([], {
+          queryParams: {
+            [this.environmentIdQueryParam]: environment.environmentId,
+          },
+          queryParamsHandling: 'merge',
+        });
+      });
+  }
+
+  private withAvailableEnvironments(
+    fn: (
+      available: DeploymentEnvironmentDto[],
+      current: DeploymentEnvironmentDto,
+    ) => void,
+    until$: Observable<unknown>,
+  ) {
+    combineLatest([
+      this.globalStateUtils.getDeploymentEnvironments(),
+      this.globalStateUtils.deploymentEnvironment$,
+    ])
+      .pipe(takeUntil(until$), take(1))
+      .subscribe(([deploymentEnvironments, selectedEnvironment]) => {
+        fn(deploymentEnvironments, selectedEnvironment);
+      });
+  }
+}

--- a/authority-portal-frontend/src/app/core/global-state/global-state-utils.ts
+++ b/authority-portal-frontend/src/app/core/global-state/global-state-utils.ts
@@ -78,11 +78,6 @@ export class GlobalStateUtils {
       map((environment) => environment.environmentId),
     );
   }
-
-  getDeploymentEnvironment(): Observable<DeploymentEnvironmentDto> {
-    return this.deploymentEnvironment$.pipe(map((environment) => environment));
-  }
-
   getDeploymentEnvironments(): Observable<DeploymentEnvironmentDto[]> {
     return this.store.select<GlobalState>(GlobalStateImpl).pipe(
       map((state) => state.deploymentEnvironments),

--- a/authority-portal-frontend/src/app/core/global-state/routes/route-config-service.ts
+++ b/authority-portal-frontend/src/app/core/global-state/routes/route-config-service.ts
@@ -92,6 +92,6 @@ export class RouteConfigService {
       .navigateByUrl('/random-redirect-for-force-refresh', {
         skipLocationChange: true,
       })
-      .then(() => this.router.navigate([currentUrl]));
+      .then(() => this.router.navigateByUrl(currentUrl));
   }
 }

--- a/authority-portal-frontend/src/app/pages/catalog-page/catalog-page/catalog-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/catalog-page/catalog-page/catalog-page.component.ts
@@ -29,6 +29,7 @@ import {
 } from '@sovity.de/authority-portal-client';
 import {GlobalStateUtils} from 'src/app/core/global-state/global-state-utils';
 import {LocalStoredValue} from 'src/app/core/utils/local-stored-value';
+import {DeploymentEnvironmentUrlSyncService} from '../../../core/global-state/deployment-environment-url-sync.service';
 import {HeaderBarConfig} from '../../../shared/common/header-bar/header-bar.model';
 import {AssetDetailDialogService} from '../asset-detail-dialog/asset-detail-dialog.service';
 import {FilterBoxItem} from '../filter-box/filter-box-item';
@@ -69,9 +70,18 @@ export class CatalogPageComponent implements OnInit, OnDestroy {
     private store: Store,
     private route: ActivatedRoute,
     private globalStateUtils: GlobalStateUtils,
+    private deploymentEnvironmentUrlSyncService: DeploymentEnvironmentUrlSyncService,
   ) {}
 
   ngOnInit(): void {
+    this.deploymentEnvironmentUrlSyncService.updateFromUrlOnce(
+      this.route,
+      this.ngOnDestroy$,
+    );
+    this.deploymentEnvironmentUrlSyncService.syncToUrl(
+      this.route,
+      this.ngOnDestroy$,
+    );
     this.initializePage();
     this.startListeningToStore();
     this.startListeningToEnvironmentChanges();

--- a/authority-portal-frontend/src/app/shared/dev-utils/env-banner/env-banner.component.ts
+++ b/authority-portal-frontend/src/app/shared/dev-utils/env-banner/env-banner.component.ts
@@ -10,7 +10,7 @@
  * Contributors:
  *      sovity GmbH - initial implementation
  */
-import {Component, OnChanges} from '@angular/core';
+import {Component} from '@angular/core';
 import {Observable} from 'rxjs';
 import {DeploymentEnvironmentDto} from '@sovity.de/authority-portal-client';
 import {GlobalStateUtils} from 'src/app/core/global-state/global-state-utils';
@@ -19,13 +19,10 @@ import {GlobalStateUtils} from 'src/app/core/global-state/global-state-utils';
   selector: 'app-env-banner',
   templateUrl: './env-banner.component.html',
 })
-export class EnvBannerComponent implements OnChanges {
+export class EnvBannerComponent {
   selectedEnvironment$!: Observable<DeploymentEnvironmentDto>;
 
   constructor(private globalStateUtils: GlobalStateUtils) {
-    this.selectedEnvironment$ =
-      this.globalStateUtils.getDeploymentEnvironment();
+    this.selectedEnvironment$ = this.globalStateUtils.deploymentEnvironment$;
   }
-
-  ngOnChanges() {}
 }


### PR DESCRIPTION
URL will now contain e.g. `http://localhost:4200/catalog?environmentId=production`

it will disappear when navigating to a non-catalog page, a global solution has not been achieved yet, as that would require checking all links for queryParamsMerge