### PR TITLE
chore: fix table header of Data Offer Types on Organizations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch
 
+- Fixed table header of Data Offer Types on Organizations page
+
 ### Known issues
 
 ### Deployment Migration Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch
 
-- Fixed table header of Data Offer Types on Organizations page
+- Adjusted the table header on the Organization overview page
 
 ### Known issues
 

--- a/authority-portal-frontend/src/app/pages/authority-organization-list-page/authority-organization-list-page/authority-organization-list-page.component.html
+++ b/authority-portal-frontend/src/app/pages/authority-organization-list-page/authority-organization-list-page/authority-organization-list-page.component.html
@@ -14,72 +14,60 @@
             <thead class="bg-gray-200 border-l-4 border-gray-200">
               <tr>
                 <th
-                  class="py-3.5 pl-4 text-sm font-normal text-gray-700 text-left"
-                  rowspan="2"
+                  class="py-3.5 pl-4 text-sm font-bold text-gray-700 text-left"
                   scope="col">
                   {{
                     ('mds-id' | isActiveFeature) ? 'MDS ID' : 'Organization ID'
                   }}
                 </th>
                 <th
-                  class="py-3.5 px-4 text-sm font-normal text-left text-gray-700"
-                  rowspan="2"
+                  class="py-3.5 px-4 text-sm font-bold text-left text-gray-700"
                   scope="col">
                   Organization Name
                 </th>
 
                 <th
-                  class="py-3.5 px-4 text-sm font-normal text-left text-gray-700"
-                  rowspan="2"
+                  class="py-3.5 px-4 text-sm font-bold text-left text-gray-700"
                   scope="col">
                   Admin Email
                 </th>
 
                 <th
-                  class="py-3.5 px-4 text-sm font-normal text-center text-gray-700"
-                  rowspan="2"
+                  class="py-3.5 px-4 text-sm font-bold text-center text-gray-700"
                   scope="col">
                   Users
                 </th>
 
                 <th
-                  class="py-3.5 px-4 text-sm font-normal text-center text-gray-700"
-                  rowspan="2"
+                  class="py-3.5 px-4 text-sm font-bold text-center text-gray-700"
                   scope="col">
                   Connectors
                 </th>
 
                 <th
-                  class="pt-3.5 px-4 text-sm font-normal text-center text-gray-700"
-                  colspan="3"
+                  class="pt-6 pb-5 px-4 text-sm font-bold text-center text-gray-700"
                   scope="col">
-                  Data Offers
+                  Data Offers<br />
+                  <span class="font-normal">On Request</span>
+                </th>
+                <th
+                  class="pt-6 pb-5 px-4 text-sm font-bold text-center text-gray-700"
+                  scope="col">
+                  Data Offers<br />
+                  <span class="font-normal">Available</span>
                 </th>
 
                 <th
-                  class="px-12 py-3.5 text-sm font-normal text-left text-gray-700"
-                  rowspan="2"
+                  class="pt-6 pb-5 px-4 text-sm font-bold text-center text-gray-700"
+                  scope="col">
+                  Data Offers<br />
+                  <span class="font-normal">Total</span>
+                </th>
+
+                <th
+                  class="px-12 py-3.5 text-sm font-bold text-left text-gray-700"
                   scope="col">
                   Status
-                </th>
-              </tr>
-              <tr>
-                <th
-                  class="py-3.5 px-4 text-sm font-normal text-center text-gray-700"
-                  scope="col">
-                  On Request
-                </th>
-
-                <th
-                  class="py-3.5 px-4 text-sm font-normal text-center text-gray-700"
-                  scope="col">
-                  Available
-                </th>
-
-                <th
-                  class="py-3.5 px-4 text-sm font-normal text-center text-gray-700"
-                  scope="col">
-                  Total
                 </th>
               </tr>
             </thead>


### PR DESCRIPTION
_What issues does this PR close?_
closes #286 UX of UI: Alignment on Organizations page of Data Offer Types

Old
![image](https://github.com/user-attachments/assets/2e05ad46-568c-4550-910a-484b7ee76a9e)

New
![image](https://github.com/user-attachments/assets/49d7c58b-0d21-4ecf-9794-067773a73a40)


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
