### PR TITLE
chore: fix delete and cancel buttons when deleting central components 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 #### Patch
 
 - Added documentation for roles and rights ([#334](https://github.com/sovity/authority-portal/issues/334))
+- Fixed Confirm and Delete buttons' behavior in confirmation modals ([#304](https://github.com/sovity/authority-portal/issues/304))
+- Fixed final step not showing when registering a central component ([#305](https://github.com/sovity/authority-portal/issues/305))
 
 ### Known issues
 

--- a/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.ts
+++ b/authority-portal-frontend/src/app/pages/component-registration-pages/register-central-component-page/register-central-component-page/register-central-component-page.component.ts
@@ -113,7 +113,7 @@ export class RegisterCentralComponentPageComponent
         () => {
           setTimeout(() => {
             this.stepper.next();
-          }, 0);
+          }, 300);
         },
       ),
     );

--- a/authority-portal-frontend/src/app/shared/common/confirmation-dialog/confirmation-dialog.component.html
+++ b/authority-portal-frontend/src/app/shared/common/confirmation-dialog/confirmation-dialog.component.html
@@ -5,7 +5,7 @@
 </mat-dialog-content>
 <mat-dialog-actions class="flex gap-3" align="end">
   <button
-    *ngFor="let button of confirmationDialog.actionButtons.reverse()"
+    *ngFor="let button of confirmationDialog.actionButtons"
     [ngClass]="button?.style || 'btn-accent-outline'"
     (click)="actionHandler(button.action)">
     {{ button.label }}

--- a/authority-portal-frontend/src/app/shared/common/confirmation-dialog/confirmation-dialog.component.ts
+++ b/authority-portal-frontend/src/app/shared/common/confirmation-dialog/confirmation-dialog.component.ts
@@ -23,10 +23,16 @@ export class ConfirmationDialogComponent {
     private dialogRef: MatDialogRef<ConfirmationDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public confirmationDialog: ConfirmationDialog,
   ) {
-    this.confirmationDialog.actionButtons.push({
-      label: 'Cancel',
-      action: 'CANCEL',
-    });
+    this.confirmationDialog = {
+      ...this.confirmationDialog,
+      actionButtons: [
+        ...this.confirmationDialog.actionButtons,
+        {
+          label: 'Cancel',
+          action: 'CANCEL',
+        },
+      ].reverse(),
+    };
   }
 
   actionHandler(action: string) {


### PR DESCRIPTION
_What issues does this PR close?_
closes #305 Operator User - Flash message is not displayed while registering central components
closes #304 Operator user - delete and cancel confirmation popup window for the central components page frequently switches between the tabs

![image](https://github.com/user-attachments/assets/9b5abb0b-a013-4309-be0e-c7aa8fbd9355)

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
