### PR TITLE
fix(trivy): prevent rate-limit issues

### DIFF
--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -37,8 +38,9 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -13,7 +13,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run license scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -32,7 +35,10 @@ jobs:
       - name: npm install (authority-portal-frontend)
         run: cd authority-portal-frontend && npm install
       - name: Run license scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -37,8 +37,8 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Run static analysis (rootfs)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -25,8 +25,8 @@ jobs:
       - name: Run static analysis (repo)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Run static analysis (rootfs)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -25,8 +26,9 @@ jobs:
       - name: Run static analysis (repo)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -12,7 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run static analysis (rootfs)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -20,7 +23,10 @@ jobs:
           format: 'table'
           severity: "CRITICAL,HIGH"
       - name: Run static analysis (repo)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"


### PR DESCRIPTION
_What issues does this PR close?_
Trivy can run into db-download-rate limits using GitHub as DB host. A newer version now introduced db-caching and additionally a mirror of the original Trivy DBs is used instead of GitHub if running into GitHub rate limits.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
