### PR TITLE
Revert "build(deps): update quarkus-bom (#342)"

### DIFF
--- a/authority-portal-backend/gradle/libs.versions.toml
+++ b/authority-portal-backend/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ npmVersion = "8.15.0"
 
 sovity-edcCe = "10.4.1"
 
-quarkus = "3.15.1"
+quarkus = "3.9.2"
 quarkus-keycloakAdminClientReactive = "3.6.6"
 quarkus-jooq = "2.0.0"
 


### PR DESCRIPTION
This reverts commit 56bb1f0103c9219655841aceb2c6af80143c7af8.

The CVE this commit tried to remedy does not affect us, because we are not using Protobuf.
I would leave the version bump in, but unfortunately it breaks DAPS connectivity so I would avoid upgrading Quarkus when it is not absolutely necessary.

