### PR TITLE
fix: add operator admin to backend dev scenario/realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 - Fixed an issue wherein a user registration could fail due to a mismatch of the internal database and the Keycloak database
 - Fixed an issue where entries in the connector overview would randomly switch places ([PR #386](https://github.com/sovity/authority-portal/pull/386))
 - Changed Client ID generation for Connectors & Central Components ([#327](https://github.com/sovity/authority-portal/issues/327))
+- Fixed missing operator admin in backend dev scenario/realm ([PR #396](https://github.com/sovity/authority-portal/pull/396))
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 - Fixed an issue wherein a user registration could fail due to a mismatch of the internal database and the Keycloak database
 - Fixed an issue where entries in the connector overview would randomly switch places ([PR #386](https://github.com/sovity/authority-portal/pull/386))
 - Changed Client ID generation for Connectors & Central Components ([#327](https://github.com/sovity/authority-portal/issues/327))
-- Fixed missing operator admin in backend dev scenario/realm ([PR #396](https://github.com/sovity/authority-portal/pull/396))
 
 ### Known issues
 

--- a/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/seeds/DevScenario.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/seeds/DevScenario.kt
@@ -92,6 +92,15 @@ class DevScenario(
                 it.name = "Service Partner Organization"
             }
 
+            // Operator Admin
+            user(8, 5) {
+                it.firstName = "Operator"
+                it.lastName = "Admin"
+            }
+            organization(5, 8) {
+                it.name = "Operator Organization"
+            }
+
             // Catalog test data
             val objectMapper = ObjectMapper()
 

--- a/authority-portal-backend/authority-portal-quarkus/src/main/resources/application.properties
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/resources/application.properties
@@ -60,6 +60,9 @@ quarkus.oidc.enabled=true
 # Participant Admin + Service Partner Admin
 %dev.quarkus.security.users.embedded.users.00000000-0000-0000-0000-000000000007=777
 %dev.quarkus.security.users.embedded.roles.00000000-0000-0000-0000-000000000007=UR_AUTHORITY-PORTAL_SERVICE_PARTNER-ADMIN,UR_AUTHORITY-PORTAL_PARTICIPANT-ADMIN,UR_AUTHORITY-PORTAL_PARTICIPANT-CURATOR,UR_AUTHORITY-PORTAL_PARTICIPANT-USER
+# Operator Admin
+%dev.quarkus.security.users.embedded.users.00000000-0000-0000-0000-000000000008=888
+%dev.quarkus.security.users.embedded.roles.00000000-0000-0000-0000-000000000008=UR_AUTHORITY-PORTAL_OPERATOR-ADMIN,UR_AUTHORITY-PORTAL_PARTICIPANT-USER
 
 %test.quarkus.oidc.enabled=false
 %test.quarkus.keycloak.devservices.enabled=false

--- a/authority-portal-backend/authority-portal-quarkus/src/main/resources/realm.dev.json
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/resources/realm.dev.json
@@ -940,6 +940,28 @@
       ]
     },
     {
+      "id": "00000000-0000-0000-0000-000000000008",
+      "createdTimestamp": 1692872833738,
+      "username": "example-operator-partner-admin",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "Operator",
+      "lastName": "Admin",
+      "email": "example@operator.admin",
+      "credentials": [],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-authority-portal"
+      ],
+      "notBefore": 0,
+      "groups": [
+        "/MDSL2222BB/Participant User",
+        "/ROLE_OPERATOR_ADMIN"
+      ]
+    },
+    {
       "id": "9525c6ea-34d5-4c11-b9f8-133dc2086f00",
       "createdTimestamp": 1691679101665,
       "username": "jdoe",


### PR DESCRIPTION
_What issues does this PR close?_
This PR adds an Operator Admin user to the backend dev scenario/realm so that the Operator Admin in the user switcher from the frontend works.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/authority-portal/blob/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
