### PR TITLE
feat: remove frontend url column from all connectors-view for authority- and operator admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 - Uptime Kuma is no longer mandatory and the status dashboard can be disabled
 - Added Owning Organization in Admin Connector Overview ([#355](https://github.com/sovity/authority-portal/issues/355))
+- Removed link to frontend URL in all-connectors-view for authority- and operator admins ([PR #398](https://github.com/sovity/authority-portal/pull/398))
 
 #### Patch
 

--- a/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/pages/connectormanagement/ConnectorManagementApiService.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/pages/connectormanagement/ConnectorManagementApiService.kt
@@ -107,12 +107,12 @@ class ConnectorManagementApiService(
         deploymentEnvironmentService.assertValidEnvId(environmentId)
 
         val connectors = connectorService.getConnectorsByEnvironment(environmentId)
-        return buildConnectorOverview(connectors, withoutFrontendUrl = true)
+        return buildConnectorOverview(connectors, showFrontendUrl = false)
     }
 
     private fun buildConnectorOverview(
         connectors: List<ConnectorRecord>,
-        withoutFrontendUrl: Boolean = false
+        showFrontendUrl: Boolean = true
     ): ConnectorOverviewResult {
         val orgNames = organizationService.getAllOrganizationNames()
 
@@ -125,7 +125,7 @@ class ConnectorManagementApiService(
                 environment = deploymentEnvironmentDtoService.findByIdOrThrow(it.environment),
                 name = it.name,
                 status = if (it.type == ConnectorType.CAAS) it.caasStatus.toDto() else it.onlineStatus.toDto(),
-                frontendUrl = if (withoutFrontendUrl) null else it.frontendUrl
+                frontendUrl = if (showFrontendUrl) it.frontendUrl else null
             )
         }
         return ConnectorOverviewResult(connectorDtos)

--- a/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/pages/connectormanagement/ConnectorManagementApiService.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/pages/connectormanagement/ConnectorManagementApiService.kt
@@ -107,10 +107,13 @@ class ConnectorManagementApiService(
         deploymentEnvironmentService.assertValidEnvId(environmentId)
 
         val connectors = connectorService.getConnectorsByEnvironment(environmentId)
-        return buildConnectorOverview(connectors)
+        return buildConnectorOverview(connectors, withoutFrontendUrl = true)
     }
 
-    private fun buildConnectorOverview(connectors: List<ConnectorRecord>): ConnectorOverviewResult {
+    private fun buildConnectorOverview(
+        connectors: List<ConnectorRecord>,
+        withoutFrontendUrl: Boolean = false
+    ): ConnectorOverviewResult {
         val orgNames = organizationService.getAllOrganizationNames()
 
         val connectorDtos = connectors.map {
@@ -122,7 +125,7 @@ class ConnectorManagementApiService(
                 environment = deploymentEnvironmentDtoService.findByIdOrThrow(it.environment),
                 name = it.name,
                 status = if (it.type == ConnectorType.CAAS) it.caasStatus.toDto() else it.onlineStatus.toDto(),
-                frontendUrl = it.frontendUrl
+                frontendUrl = if (withoutFrontendUrl) null else it.frontendUrl
             )
         }
         return ConnectorOverviewResult(connectorDtos)

--- a/authority-portal-backend/authority-portal-quarkus/src/test/kotlin/de/sovity/authorityportal/web/tests/services/connector/ConnectorManagementApiServiceTest.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/test/kotlin/de/sovity/authorityportal/web/tests/services/connector/ConnectorManagementApiServiceTest.kt
@@ -158,6 +158,7 @@ class ConnectorManagementApiServiceTest {
         assertThat(result.connectors).hasSize(2)
         assertThat(result.connectors).noneMatch { it.environment.environmentId != "test" }
         assertThat(result.connectors).noneMatch { it.id == dummyDevConnectorId(0, 2) }
+        assertThat(result.connectors).allMatch { it.frontendUrl == null }
 
         assertThat(result.connectors[0].id).isEqualTo(dummyDevConnectorId(0, 0))
         assertThat(result.connectors[1].id).isEqualTo(dummyDevConnectorId(0, 1))
@@ -191,6 +192,7 @@ class ConnectorManagementApiServiceTest {
         assertThat(result.connectors).noneMatch { it.environment.environmentId != "other-environment" }
         assertThat(result.connectors).noneMatch { it.id == dummyDevConnectorId(0, 0) }
         assertThat(result.connectors).noneMatch { it.id == dummyDevConnectorId(0, 1) }
+        assertThat(result.connectors).allMatch { it.frontendUrl == null }
 
         assertThat(result.connectors[0].id).isEqualTo(dummyDevConnectorId(0, 2))
         assertThat(result.connectors[0].environment.environmentId).isEqualTo("other-environment")

--- a/authority-portal-frontend/src/app/pages/authority-connector-list-page/authority-connector-list-page/authority-connector-list-page.component.html
+++ b/authority-portal-frontend/src/app/pages/authority-connector-list-page/authority-connector-list-page/authority-connector-list-page.component.html
@@ -44,12 +44,6 @@
                   scope="col">
                   Environment
                 </th>
-
-                <th
-                  class="py-3.5 text-sm font-normal text-gray-700 text-left"
-                  scope="col">
-                  Frontend
-                </th>
               </tr>
             </thead>
 
@@ -94,19 +88,6 @@
                     </td>
                     <td class="py-8 text-sm whitespace-nowrap text-gray-700">
                       {{ connector.environment.title }}
-                    </td>
-                    <td class="text-sm whitespace-nowrap">
-                      <a
-                        *ngIf="connector.frontendUrl"
-                        class="flex items-center justify-center group active:scale-[0.98] p-4"
-                        target="_blank"
-                        [href]="connector.frontendUrl"
-                        (click)="frontendLinkClicked = true">
-                        <mat-icon
-                          class="!text-[16px] !mt-[9px] !text-gray-600 group-hover:!text-brand-500"
-                          >open_in_new</mat-icon
-                        >
-                      </a>
                     </td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
_What issues does this PR close?_
This PR removes the column with the link to the frontend URL to the connectors from the table of the all-connector-view of Authority- and Operator-Admins.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/authority-portal/blob/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
