### PR TITLE
fix: allow operator admins to delete all connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch
 
-- Fixed Keycloak dev realm for local E2E development
+- Fixed Keycloak dev realm for local E2E development ([PR #405](https://github.com/sovity/authority-portal/pull/405))
+- Fixed Operator Admins being unable to delete connectors ([PR #408](https://github.com/sovity/authority-portal/pull/408))
 
 ### Known issues
 

--- a/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/UiResourceImpl.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/UiResourceImpl.kt
@@ -308,9 +308,15 @@ class UiResourceImpl(
 
     @Transactional
     override fun deleteProvidedConnector(connectorId: String): IdResponse {
-        authUtils.requiresRole(Roles.UserRoles.SERVICE_PARTNER_ADMIN)
-        authUtils.requiresMemberOfAnyOrganization()
-        return connectorManagementApiService.deleteOwnOrProvidedConnector(
+        authUtils.requiresAnyRole(Roles.UserRoles.SERVICE_PARTNER_ADMIN, Roles.UserRoles.OPERATOR_ADMIN)
+
+        if (!authUtils.hasRole(Roles.UserRoles.OPERATOR_ADMIN)) {
+            authUtils.requiresMemberOfProviderOrganization(connectorId)
+        } else {
+            authUtils.requiresMemberOfAnyOrganization()
+        }
+
+        return connectorManagementApiService.deleteConnectorById(
             connectorId,
             loggedInUser.organizationId!!,
             loggedInUser.userId
@@ -369,8 +375,8 @@ class UiResourceImpl(
     @Transactional
     override fun deleteOwnConnector(connectorId: String): IdResponse {
         authUtils.requiresRole(Roles.UserRoles.PARTICIPANT_CURATOR)
-        authUtils.requiresMemberOfAnyOrganization()
-        return connectorManagementApiService.deleteOwnOrProvidedConnector(
+        authUtils.requiresMemberOfOwningOrganization(connectorId)
+        return connectorManagementApiService.deleteConnectorById(
             connectorId,
             loggedInUser.organizationId!!,
             loggedInUser.userId

--- a/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/auth/AuthUtils.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/auth/AuthUtils.kt
@@ -15,24 +15,20 @@ package de.sovity.authorityportal.web.auth
 
 import de.sovity.authorityportal.db.jooq.enums.OrganizationRegistrationStatus
 import de.sovity.authorityportal.db.jooq.enums.UserRegistrationStatus
+import de.sovity.authorityportal.web.services.ConnectorService
 import de.sovity.authorityportal.web.services.OrganizationService
 import de.sovity.authorityportal.web.services.UserService
 import de.sovity.authorityportal.web.utils.unauthorized
 import io.quarkus.logging.Log
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.inject.Inject
 
 @ApplicationScoped
-class AuthUtils {
-    @Inject
-    lateinit var loggedInUser: LoggedInUser
-
-    @Inject
-    lateinit var userService: UserService
-
-    @Inject
-    lateinit var organizationService: OrganizationService
-
+class AuthUtils(
+    val loggedInUser: LoggedInUser,
+    val userService: UserService,
+    val organizationService: OrganizationService,
+    val connectorService: ConnectorService
+) {
     fun requiresAuthenticated() {
         if (!loggedInUser.authenticated) {
             Log.error("User is not authenticated.")
@@ -149,13 +145,32 @@ class AuthUtils {
     }
 
     fun requiresOrganizationRegistrationStatus(status: OrganizationRegistrationStatus) {
-        requiresAuthenticated()
         requiresMemberOfAnyOrganization()
 
         val organization = organizationService.getOrganizationOrThrow(loggedInUser.organizationId!!)
         if (organization.registrationStatus != status) {
             Log.error("User can only perform the action if their organization is in the onboarding phase. userId=${loggedInUser.userId}, organizationId=${organization.id}")
             unauthorized("User can only perform the action if their organization is in the onboarding phase")
+        }
+    }
+
+    fun requiresMemberOfProviderOrganization(connectorId: String) {
+        requiresMemberOfAnyOrganization()
+
+        val connector = connectorService.getConnectorOrThrow(connectorId)
+        if (connector.providerOrganizationId != loggedInUser.organizationId!!) {
+            Log.error("User is not a member of the provider organization. userId=${loggedInUser.userId}, providerOrganizationId=${connector.providerOrganizationId}")
+            unauthorized("User is not a member of the provider organization")
+        }
+    }
+
+    fun requiresMemberOfOwningOrganization(connectorId: String) {
+        requiresMemberOfAnyOrganization()
+
+        val connector = connectorService.getConnectorOrThrow(connectorId)
+        if (!connectorId.startsWith(loggedInUser.organizationId!!)) {
+            Log.error("User is not a member of the owning organization. userId=${loggedInUser.userId}, organizationId=${connector.organizationId}")
+            unauthorized("User is not a member of the owning organization")
         }
     }
 }

--- a/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/pages/connectormanagement/ConnectorManagementApiService.kt
+++ b/authority-portal-backend/authority-portal-quarkus/src/main/kotlin/de/sovity/authorityportal/web/pages/connectormanagement/ConnectorManagementApiService.kt
@@ -335,17 +335,12 @@ class ConnectorManagementApiService(
         return url.trim().removeSuffix("/")
     }
 
-    fun deleteOwnOrProvidedConnector(
+    fun deleteConnectorById(
         connectorId: String,
         organizationId: String,
         userId: String
     ): IdResponse {
         val connector = connectorService.getConnectorOrThrow(connectorId)
-
-        if (!connectorId.startsWith(organizationId) && connector.providerOrganizationId != organizationId) {
-            Log.error("To be deleted connector does not belong to user's organization and is not hosted by it. connectorId=$connectorId, organizationId=$organizationId, userId=$userId.")
-            error("Connector ID does not match the ID of the user's organization or host organization")
-        }
 
         deleteConnector(connector)
         Log.info("Connector unregistered. connectorId=$connectorId, organizationId=$organizationId, userId=$userId.")
@@ -353,8 +348,8 @@ class ConnectorManagementApiService(
         return IdResponse(connectorId, timeUtils.now())
     }
 
-    fun deleteAllOrganizationConnectors(organizationid: String) {
-        val connectors = connectorService.getConnectorsByOrganizationId(organizationid)
+    fun deleteAllOrganizationConnectors(organizationId: String) {
+        val connectors = connectorService.getConnectorsByOrganizationId(organizationId)
         connectors.forEach { deleteConnector(it) }
     }
 

--- a/authority-portal-frontend/src/app/pages/authority-connector-list-page/state/authority-connector-list-page-state-impl.ts
+++ b/authority-portal-frontend/src/app/pages/authority-connector-list-page/state/authority-connector-list-page-state-impl.ts
@@ -105,7 +105,7 @@ export class AuthorityConnectorListPageStateImpl {
     }
     ctx.patchState({busy: true});
 
-    return this.apiService.deleteOwnConnector(action.connectorId).pipe(
+    return this.apiService.deleteProvidedConnector(action.connectorId).pipe(
       switchMap(() => this.globalStateUtils.getDeploymentEnvironmentId()),
       switchMap((deploymentEnvironmentId) =>
         this.apiService.getAllConnectors(deploymentEnvironmentId),


### PR DESCRIPTION
_What issues does this PR close?_
Deleting a connector from the `All Connectors` view as an Operator Admin resulted always in an error, this PR fixes this.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/authority-portal/blob/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
