### PR TITLE
chore: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/actions/build-connector-image/action.yml
+++ b/.github/actions/build-connector-image/action.yml
@@ -29,11 +29,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
     - name: "Docker: Log in to the Container registry"
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
       with:
         registry: ${{ inputs.registry-url }}
         username: ${{ inputs.registry-user }}
@@ -49,7 +49,7 @@ runs:
         echo "BUILD_DATE=$(date --utc +%FT%TZ)" >> $GITHUB_ENV
     - name: "Docker: Extract metadata (tags, labels)"
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
       with:
         images: ${{ inputs.registry-url }}/${{ inputs.image-base-name }}/${{ inputs.image-name }}
         labels: |
@@ -66,7 +66,7 @@ runs:
           type=raw,value=latest,enable={{is_default_branch}}
           type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/tags/') }}
     - name: "Docker: Build and Push"
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         file: authority-portal-backend/catalog-crawler/Dockerfile
         context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,35 +52,35 @@ jobs:
       quarkus.datasource.password: portal
       quarkus.flyway.clean-at-start: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: "21"
           distribution: "temurin"
       - name: "Gradle: Validate Gradle Wrapper"
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      - name: "Gradle: Set up Gradle"
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
       - name: "Gradle: Build"
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+        working-directory: authority-portal-backend
         env:
           GPR_USER: ${{ secrets.GHCR_READONLY_USER }}
           GPR_KEY: ${{ secrets.GHCR_READONLY_TOKEN }}
-        with:
-          build-root-directory: authority-portal-backend
-          arguments: build
+        run: ./gradlew build
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: "Docker: Log in to the Container registry"
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Docker: Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BASE }}/${{ env.IMAGE_NAME }}
           labels: |
@@ -97,7 +97,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - name: "Docker: Build and Push Image (ds-portal-ce-backend)"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: authority-portal-backend/authority-portal-quarkus/src/main/docker/Dockerfile.jvm
           context: authority-portal-backend/authority-portal-quarkus
@@ -131,31 +131,31 @@ jobs:
       IMAGE_TITLE: Data Space Portal Frontend
       IMAGE_DESCRIPTION: Frontend for the sovity Data Space Portal
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: "21"
           distribution: "temurin"
       - name: "Gradle: Validate Gradle Wrapper"
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      - name: "Gradle: Set up Gradle"
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
       - name: "Gradle: Generate TypeScript Library Code"
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+        working-directory: authority-portal-backend
         env:
           GPR_USER: ${{ secrets.GHCR_READONLY_USER }}
           GPR_KEY: ${{ secrets.GHCR_READONLY_TOKEN }}
-        with:
-          build-root-directory: authority-portal-backend
-          arguments: :authority-portal-api:openApiGenerateTypeScriptClient
+        run: ./gradlew :authority-portal-api:openApiGenerateTypeScriptClient
       - name: "Set up Node 24"
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           cache: "npm"
           cache-dependency-path: |
             authority-portal-frontend/package-lock.json
       - name: "Set up Chrome"
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
       - name: "NPM: Install Dependencies"
         run: cd authority-portal-frontend && npm ci
       - name: "NPM: Test Frontend"
@@ -163,18 +163,18 @@ jobs:
       - name: "NPM: Build Frontend"
         run: cd authority-portal-frontend && npm run build
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: "Docker: Log in to the Container registry"
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Docker: Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BASE }}/${{ env.IMAGE_NAME }}
           labels: |
@@ -191,7 +191,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - name: "Docker: Build and Push Image"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: authority-portal-frontend/docker/Dockerfile
           context: authority-portal-frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           java-version: "21"
           distribution: "temurin"
       - name: "Gradle: Validate Gradle Wrapper"
-        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
       - name: "Gradle: Set up Gradle"
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
       - name: "Gradle: Build"
@@ -138,7 +138,7 @@ jobs:
           java-version: "21"
           distribution: "temurin"
       - name: "Gradle: Validate Gradle Wrapper"
-        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
       - name: "Gradle: Set up Gradle"
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
       - name: "Gradle: Generate TypeScript Library Code"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
         build-mode: ${{ matrix.build-mode }}
 
     - name: "Gradle: Validate Gradle Wrapper"
-      uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
     - name: "Gradle: Set up Gradle"
       uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,33 +35,33 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin'
         java-version: '21'
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: "Gradle: Validate Gradle Wrapper"
-      uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+      uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
 
+    - name: "Gradle: Set up Gradle"
+      uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
     - name: "Gradle: Build"
-      uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+      working-directory: authority-portal-backend
       env:
         GPR_USER: ${{ secrets.GHCR_READONLY_USER }}
         GPR_KEY: ${{ secrets.GHCR_READONLY_TOKEN }}
-      with:
-        build-root-directory: authority-portal-backend
-        arguments: build
+      run: ./gradlew build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
       env:
         GPR_USER: ${{ secrets.GHCR_READONLY_USER }}
         GPR_KEY: ${{ secrets.GHCR_READONLY_TOKEN }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Check out the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Git
       run: |


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to specific SHA commits instead of mutable version tags
- Prevents supply chain attacks where a tag could be moved to point to malicious code

## Test plan

- [x] Verify CI workflows still run correctly after the pin